### PR TITLE
Add ROS 1 and ROS 2 compatibility to stamped_msgs

### DIFF
--- a/.github/workflows/ci-ros1.yaml
+++ b/.github/workflows/ci-ros1.yaml
@@ -1,0 +1,44 @@
+# SPDX-License-Identifier: BSD-3-Clause
+# SPDX-FileCopyrightText: Czech Technical University in Prague
+
+# This config uses industrial_ci (https://github.com/ros-industrial/industrial_ci.git).
+# For troubleshooting, see readme (https://github.com/ros-industrial/industrial_ci/blob/master/README.rst)
+
+name: CI ROS 1
+
+# This determines when this workflow is run
+on:
+  push:
+    branches: [master]
+  pull_request:
+    branches: [master]
+  workflow_dispatch: {}
+
+jobs:
+  industrial_ci:
+    strategy:
+      matrix:
+        env:
+          - {ROS_DISTRO: noetic, ROS_REPO: testing, DOCKER_IMAGE: "ros:noetic-perception-focal"}
+          - {ROS_DISTRO: melodic, ROS_REPO: testing, DOCKER_IMAGE: "ros:melodic-perception-bionic"}
+        os: ["ubuntu-24.04", "ubuntu-24.04-arm"]
+    name: "${{ matrix.env.ROS_DISTRO }}-${{ matrix.os }}"
+    env:
+      CCACHE_DIR: ${{ github.workspace }}/.ccache # Directory for ccache (and how we enable ccache in industrial_ci)
+    runs-on: ${{ matrix.os }}
+    steps:
+      - uses: actions/checkout@v6
+      # This step will fetch/store the directory used by ccache before/after the ci run
+      - name: Cache ccache
+        uses: rhaschke/cache@main
+        with:
+          path: ${{ env.CCACHE_DIR }}
+          key: ccache-${{ matrix.os }}-${{ matrix.env.ROS_DISTRO }}-${{ matrix.env.ROS_REPO }}-${{ github.sha }}-${{ github.run_id }}
+          restore-keys: |
+            ccache-${{ matrix.os }}-${{ matrix.env.ROS_DISTRO }}-${{ matrix.env.ROS_REPO }}-${{ github.sha }}
+            ccache-${{ matrix.os }}-${{ matrix.env.ROS_DISTRO }}
+        env:
+          GHA_CACHE_SAVE: always
+      # Run industrial_ci
+      - uses: 'ros-industrial/industrial_ci@master'
+        env: ${{ matrix.env }}

--- a/.github/workflows/ci-ros2.yaml
+++ b/.github/workflows/ci-ros2.yaml
@@ -1,0 +1,47 @@
+# SPDX-License-Identifier: BSD-3-Clause
+# SPDX-FileCopyrightText: Czech Technical University in Prague
+
+# This config uses industrial_ci (https://github.com/ros-industrial/industrial_ci.git).
+# For troubleshooting, see readme (https://github.com/ros-industrial/industrial_ci/blob/master/README.rst)
+
+name: CI ROS 2
+
+# This determines when this workflow is run
+on:
+  push:
+    branches: [master]
+  pull_request:
+    branches: [master]
+  workflow_dispatch: {}
+
+jobs:
+  industrial_ci:
+    strategy:
+      fail-fast: false
+      matrix:
+        env:
+          - {ROS_DISTRO: jazzy, ROS_REPO: testing, DOCKER_IMAGE: "ghcr.io/sloretz/ros:jazzy-perception", ALLOW_FAIL: no}
+          - {ROS_DISTRO: kilted, ROS_REPO: testing, DOCKER_IMAGE: "ghcr.io/sloretz/ros:kilted-perception", ALLOW_FAIL: no}
+          - {ROS_DISTRO: rolling, ROS_REPO: testing, DOCKER_IMAGE: "ghcr.io/sloretz/ros:rolling-perception", ALLOW_FAIL: yes}
+        os: ["ubuntu-24.04", "ubuntu-24.04-arm"]
+    name: "${{ matrix.env.ROS_DISTRO }}-${{ matrix.os }}"
+    env:
+      CCACHE_DIR: ${{ github.workspace }}/.ccache # Directory for ccache (and how we enable ccache in industrial_ci)
+    runs-on: ${{ matrix.os }}
+    steps:
+      - uses: actions/checkout@v6
+      # This step will fetch/store the directory used by ccache before/after the ci run
+      - name: Cache ccache
+        uses: rhaschke/cache@main
+        continue-on-error: ${{ matrix.env.ALLOW_FAIL }}
+        with:
+          path: ${{ env.CCACHE_DIR }}
+          key: ccache-${{ matrix.os }}-${{ matrix.env.ROS_DISTRO }}-${{ matrix.env.ROS_REPO }}-${{ github.sha }}-${{ github.run_id }}
+          restore-keys: |
+            ccache-${{ matrix.os }}-${{ matrix.env.ROS_DISTRO }}-${{ matrix.env.ROS_REPO }}-${{ github.sha }}
+            ccache-${{ matrix.os }}-${{ matrix.env.ROS_DISTRO }}
+        env:
+          GHA_CACHE_SAVE: always
+      # Run industrial_ci
+      - uses: 'ros-industrial/industrial_ci@master'
+        env: ${{ matrix.env }}

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -1,82 +1,148 @@
-cmake_minimum_required(VERSION 3.8)
+cmake_minimum_required(VERSION 3.5)
 project(stamped_msgs)
 
-# Check if ROS2 environment is sourced
-if(NOT DEFINED ENV{ROS_DISTRO})
-  message(FATAL_ERROR "ROS2 environment is not sourced! Please run: source /opt/ros/jazzy/setup.bash")
+find_package(ament_cmake QUIET)
+find_package(catkin QUIET)
+
+if(catkin_FOUND)
+  ## ROS 1 build -----------------------------------------------------------------------------------------
+  set(MESSAGE_DEPS
+    std_msgs
+  )
+
+  find_package(catkin REQUIRED COMPONENTS
+    message_generation
+    ${MESSAGE_DEPS}
+  )
+
+  add_message_files(
+    FILES
+    Bool.msg
+    BoolArray.msg
+    Byte.msg
+    ByteArray.msg
+    ByteMultiArray.msg
+    Char.msg
+    CharArray.msg
+    ColorRGBA.msg
+    ColorRGBAArray.msg
+    Duration.msg
+    DurationArray.msg
+    Empty.msg
+    Float32.msg
+    Float32Array.msg
+    Float32MultiArray.msg
+    Float64.msg
+    Float64Array.msg
+    Float64MultiArray.msg
+    Int16.msg
+    Int16Array.msg
+    Int16MultiArray.msg
+    Int32.msg
+    Int32Array.msg
+    Int32MultiArray.msg
+    Int64.msg
+    Int64Array.msg
+    Int64MultiArray.msg
+    Int8.msg
+    Int8Array.msg
+    Int8MultiArray.msg
+    String.msg
+    StringArray.msg
+    UInt16.msg
+    UInt16Array.msg
+    UInt16MultiArray.msg
+    UInt32.msg
+    UInt32Array.msg
+    UInt32MultiArray.msg
+    UInt64.msg
+    UInt64Array.msg
+    UInt64MultiArray.msg
+    UInt8.msg
+    UInt8Array.msg
+    UInt8MultiArray.msg
+  )
+
+  generate_messages(DEPENDENCIES ${MESSAGE_DEPS})
+
+  catkin_package(
+    CATKIN_DEPENDS message_runtime ${MESSAGE_DEPS}
+  )
+  ## ----------------------------------------------------------------------------------------------------
+elseif(ament_cmake_FOUND)
+  ## ROS 2 build -----------------------------------------------------------------------------------------
+  if(NOT CMAKE_CXX_STANDARD)
+    set(CMAKE_CXX_STANDARD 17)
+  endif()
+
+  if(CMAKE_COMPILER_IS_GNUCXX OR CMAKE_CXX_COMPILER_ID MATCHES "Clang")
+    add_compile_options(-Wall -Wextra -Wpedantic)
+  endif()
+
+  find_package(ament_cmake REQUIRED)
+  find_package(rosidl_default_generators REQUIRED)
+  find_package(std_msgs REQUIRED)
+  find_package(builtin_interfaces REQUIRED)
+
+  # Duration.msg and DurationArray.msg use builtin_interfaces/Duration in ROS 2 (msg_ros2/)
+  # instead of the primitive 'duration' type used in ROS 1 (msg/)
+  set(msg_files
+    "msg/Bool.msg"
+    "msg/BoolArray.msg"
+    "msg/Byte.msg"
+    "msg/ByteArray.msg"
+    "msg/ByteMultiArray.msg"
+    "msg/Char.msg"
+    "msg/CharArray.msg"
+    "msg/ColorRGBA.msg"
+    "msg/ColorRGBAArray.msg"
+    "${CMAKE_CURRENT_SOURCE_DIR}/msg_ros2:msg/Duration.msg"
+    "${CMAKE_CURRENT_SOURCE_DIR}/msg_ros2:msg/DurationArray.msg"
+    "msg/Empty.msg"
+    "msg/Float32.msg"
+    "msg/Float32Array.msg"
+    "msg/Float32MultiArray.msg"
+    "msg/Float64.msg"
+    "msg/Float64Array.msg"
+    "msg/Float64MultiArray.msg"
+    "msg/Int16.msg"
+    "msg/Int16Array.msg"
+    "msg/Int16MultiArray.msg"
+    "msg/Int32.msg"
+    "msg/Int32Array.msg"
+    "msg/Int32MultiArray.msg"
+    "msg/Int64.msg"
+    "msg/Int64Array.msg"
+    "msg/Int64MultiArray.msg"
+    "msg/Int8.msg"
+    "msg/Int8Array.msg"
+    "msg/Int8MultiArray.msg"
+    "msg/String.msg"
+    "msg/StringArray.msg"
+    "msg/UInt16.msg"
+    "msg/UInt16Array.msg"
+    "msg/UInt16MultiArray.msg"
+    "msg/UInt32.msg"
+    "msg/UInt32Array.msg"
+    "msg/UInt32MultiArray.msg"
+    "msg/UInt64.msg"
+    "msg/UInt64Array.msg"
+    "msg/UInt64MultiArray.msg"
+    "msg/UInt8.msg"
+    "msg/UInt8Array.msg"
+    "msg/UInt8MultiArray.msg"
+  )
+
+  rosidl_generate_interfaces(${PROJECT_NAME}
+    ${msg_files}
+    DEPENDENCIES std_msgs builtin_interfaces
+    ADD_LINTER_TESTS
+  )
+
+  ament_export_dependencies(rosidl_default_runtime)
+
+  ament_package()
+  ## ----------------------------------------------------------------------------------------------------
+else()
+  message(FATAL_ERROR "Neither catkin nor ament_cmake found.")
 endif()
-
-# Default to C++17
-if(NOT CMAKE_CXX_STANDARD)
-  set(CMAKE_CXX_STANDARD 17)
-endif()
-
-if(CMAKE_COMPILER_IS_GNUCXX OR CMAKE_CXX_COMPILER_ID MATCHES "Clang")
-  add_compile_options(-Wall -Wextra -Wpedantic)
-endif()
-
-# Find dependencies
-find_package(ament_cmake REQUIRED)
-find_package(rosidl_default_generators REQUIRED)
-find_package(std_msgs REQUIRED)
-find_package(builtin_interfaces REQUIRED)
-
-# Define all message files
-set(msg_files
-  "msg/Bool.msg"
-  "msg/BoolArray.msg"
-  "msg/Byte.msg"
-  "msg/ByteArray.msg"
-  "msg/ByteMultiArray.msg"
-  "msg/Char.msg"
-  "msg/CharArray.msg"
-  "msg/ColorRGBA.msg"
-  "msg/ColorRGBAArray.msg"
-  "msg/Duration.msg"
-  "msg/DurationArray.msg"
-  "msg/Empty.msg"
-  "msg/Float32.msg"
-  "msg/Float32Array.msg"
-  "msg/Float32MultiArray.msg"
-  "msg/Float64.msg"
-  "msg/Float64Array.msg"
-  "msg/Float64MultiArray.msg"
-  "msg/Int16.msg"
-  "msg/Int16Array.msg"
-  "msg/Int16MultiArray.msg"
-  "msg/Int32.msg"
-  "msg/Int32Array.msg"
-  "msg/Int32MultiArray.msg"
-  "msg/Int64.msg"
-  "msg/Int64Array.msg"
-  "msg/Int64MultiArray.msg"
-  "msg/Int8.msg"
-  "msg/Int8Array.msg"
-  "msg/Int8MultiArray.msg"
-  "msg/String.msg"
-  "msg/StringArray.msg"
-  "msg/UInt16.msg"
-  "msg/UInt16Array.msg"
-  "msg/UInt16MultiArray.msg"
-  "msg/UInt32.msg"
-  "msg/UInt32Array.msg"
-  "msg/UInt32MultiArray.msg"
-  "msg/UInt64.msg"
-  "msg/UInt64Array.msg"
-  "msg/UInt64MultiArray.msg"
-  "msg/UInt8.msg"
-  "msg/UInt8Array.msg"
-  "msg/UInt8MultiArray.msg"
-)
-
-# Generate messages
-rosidl_generate_interfaces(${PROJECT_NAME}
-  ${msg_files}
-  DEPENDENCIES std_msgs builtin_interfaces
-  ADD_LINTER_TESTS
-)
-
-# Export dependencies
-ament_export_dependencies(rosidl_default_runtime)
-
-ament_package()

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -1,65 +1,82 @@
-cmake_minimum_required(VERSION 3.10.2)
+cmake_minimum_required(VERSION 3.8)
 project(stamped_msgs)
 
-set(MESSAGE_DEPS
-  std_msgs
+# Check if ROS2 environment is sourced
+if(NOT DEFINED ENV{ROS_DISTRO})
+  message(FATAL_ERROR "ROS2 environment is not sourced! Please run: source /opt/ros/jazzy/setup.bash")
+endif()
+
+# Default to C++17
+if(NOT CMAKE_CXX_STANDARD)
+  set(CMAKE_CXX_STANDARD 17)
+endif()
+
+if(CMAKE_COMPILER_IS_GNUCXX OR CMAKE_CXX_COMPILER_ID MATCHES "Clang")
+  add_compile_options(-Wall -Wextra -Wpedantic)
+endif()
+
+# Find dependencies
+find_package(ament_cmake REQUIRED)
+find_package(rosidl_default_generators REQUIRED)
+find_package(std_msgs REQUIRED)
+find_package(builtin_interfaces REQUIRED)
+
+# Define all message files
+set(msg_files
+  "msg/Bool.msg"
+  "msg/BoolArray.msg"
+  "msg/Byte.msg"
+  "msg/ByteArray.msg"
+  "msg/ByteMultiArray.msg"
+  "msg/Char.msg"
+  "msg/CharArray.msg"
+  "msg/ColorRGBA.msg"
+  "msg/ColorRGBAArray.msg"
+  "msg/Duration.msg"
+  "msg/DurationArray.msg"
+  "msg/Empty.msg"
+  "msg/Float32.msg"
+  "msg/Float32Array.msg"
+  "msg/Float32MultiArray.msg"
+  "msg/Float64.msg"
+  "msg/Float64Array.msg"
+  "msg/Float64MultiArray.msg"
+  "msg/Int16.msg"
+  "msg/Int16Array.msg"
+  "msg/Int16MultiArray.msg"
+  "msg/Int32.msg"
+  "msg/Int32Array.msg"
+  "msg/Int32MultiArray.msg"
+  "msg/Int64.msg"
+  "msg/Int64Array.msg"
+  "msg/Int64MultiArray.msg"
+  "msg/Int8.msg"
+  "msg/Int8Array.msg"
+  "msg/Int8MultiArray.msg"
+  "msg/String.msg"
+  "msg/StringArray.msg"
+  "msg/UInt16.msg"
+  "msg/UInt16Array.msg"
+  "msg/UInt16MultiArray.msg"
+  "msg/UInt32.msg"
+  "msg/UInt32Array.msg"
+  "msg/UInt32MultiArray.msg"
+  "msg/UInt64.msg"
+  "msg/UInt64Array.msg"
+  "msg/UInt64MultiArray.msg"
+  "msg/UInt8.msg"
+  "msg/UInt8Array.msg"
+  "msg/UInt8MultiArray.msg"
 )
 
-find_package(catkin REQUIRED COMPONENTS
-  message_generation
-  ${MESSAGE_DEPS}
+# Generate messages
+rosidl_generate_interfaces(${PROJECT_NAME}
+  ${msg_files}
+  DEPENDENCIES std_msgs builtin_interfaces
+  ADD_LINTER_TESTS
 )
 
-add_message_files(
- FILES
-  Bool.msg
-  BoolArray.msg
-  Byte.msg
-  ByteArray.msg
-  ByteMultiArray.msg
-  Char.msg
-  CharArray.msg
-  ColorRGBA.msg
-  ColorRGBAArray.msg
-  Duration.msg
-  DurationArray.msg
-  Empty.msg
-  Float32.msg
-  Float32Array.msg
-  Float32MultiArray.msg
-  Float64.msg
-  Float64Array.msg
-  Float64MultiArray.msg
-  Int16.msg
-  Int16Array.msg
-  Int16MultiArray.msg
-  Int32.msg
-  Int32Array.msg
-  Int32MultiArray.msg
-  Int64.msg
-  Int64Array.msg
-  Int64MultiArray.msg
-  Int8.msg
-  Int8Array.msg
-  Int8MultiArray.msg
-  String.msg
-  StringArray.msg
-  UInt16.msg
-  UInt16Array.msg
-  UInt16MultiArray.msg
-  UInt32.msg
-  UInt32Array.msg
-  UInt32MultiArray.msg
-  UInt64.msg
-  UInt64Array.msg
-  UInt64MultiArray.msg
-  UInt8.msg
-  UInt8Array.msg
-  UInt8MultiArray.msg
-)
+# Export dependencies
+ament_export_dependencies(rosidl_default_runtime)
 
-generate_messages(DEPENDENCIES ${MESSAGE_DEPS})
-
-catkin_package(
-  CATKIN_DEPENDS message_runtime ${MESSAGE_DEPS}
-)
+ament_package()

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -1,11 +1,11 @@
-cmake_minimum_required(VERSION 3.5)
+cmake_minimum_required(VERSION 3.10.2)
 project(stamped_msgs)
 
 find_package(ament_cmake QUIET)
 find_package(catkin QUIET)
 
 if(catkin_FOUND)
-  ## ROS 1 build -----------------------------------------------------------------------------------------
+  ## ROS 1 build
   set(MESSAGE_DEPS
     std_msgs
   )
@@ -68,16 +68,8 @@ if(catkin_FOUND)
   catkin_package(
     CATKIN_DEPENDS message_runtime ${MESSAGE_DEPS}
   )
-  ## ----------------------------------------------------------------------------------------------------
 elseif(ament_cmake_FOUND)
-  ## ROS 2 build -----------------------------------------------------------------------------------------
-  if(NOT CMAKE_CXX_STANDARD)
-    set(CMAKE_CXX_STANDARD 17)
-  endif()
-
-  if(CMAKE_COMPILER_IS_GNUCXX OR CMAKE_CXX_COMPILER_ID MATCHES "Clang")
-    add_compile_options(-Wall -Wextra -Wpedantic)
-  endif()
+  ## ROS 2 build
 
   find_package(ament_cmake REQUIRED)
   find_package(rosidl_default_generators REQUIRED)
@@ -142,7 +134,6 @@ elseif(ament_cmake_FOUND)
   ament_export_dependencies(rosidl_default_runtime)
 
   ament_package()
-  ## ----------------------------------------------------------------------------------------------------
 else()
   message(FATAL_ERROR "Neither catkin nor ament_cmake found.")
 endif()

--- a/README.md
+++ b/README.md
@@ -10,3 +10,7 @@ More reading e.g. here:
 
 - https://github.com/ros/std_msgs/issues/7
 - https://answers.ros.org/question/9715/stamped-std_msgs/
+
+## Building
+
+This repo is compatible with both ROS 1 and ROS 2. Just use catkin/ament/colcon as usual to build these messages.

--- a/msg/Bool.msg
+++ b/msg/Bool.msg
@@ -1,2 +1,2 @@
-Header header
+std_msgs/Header header
 bool data

--- a/msg/BoolArray.msg
+++ b/msg/BoolArray.msg
@@ -1,2 +1,2 @@
-Header header
+std_msgs/Header header
 bool[] data

--- a/msg/Byte.msg
+++ b/msg/Byte.msg
@@ -1,2 +1,2 @@
-Header header
+std_msgs/Header header
 byte data

--- a/msg/ByteArray.msg
+++ b/msg/ByteArray.msg
@@ -1,2 +1,2 @@
-Header header
+std_msgs/Header header
 byte[] data

--- a/msg/ByteMultiArray.msg
+++ b/msg/ByteMultiArray.msg
@@ -1,3 +1,3 @@
-Header header
+std_msgs/Header header
 std_msgs/MultiArrayLayout  layout        # specification of data layout
 byte[] data

--- a/msg/Char.msg
+++ b/msg/Char.msg
@@ -1,2 +1,2 @@
-Header header
+std_msgs/Header header
 char data

--- a/msg/CharArray.msg
+++ b/msg/CharArray.msg
@@ -1,2 +1,2 @@
-Header header
+std_msgs/Header header
 char[] data

--- a/msg/ColorRGBA.msg
+++ b/msg/ColorRGBA.msg
@@ -1,4 +1,4 @@
-Header header
+std_msgs/Header header
 float32 r
 float32 g
 float32 b

--- a/msg/ColorRGBAArray.msg
+++ b/msg/ColorRGBAArray.msg
@@ -1,2 +1,2 @@
-Header header
+std_msgs/Header header
 std_msgs/ColorRGBA[] data

--- a/msg/Duration.msg
+++ b/msg/Duration.msg
@@ -1,2 +1,2 @@
 std_msgs/Header header
-builtin_interfaces/Duration data
+duration data

--- a/msg/Duration.msg
+++ b/msg/Duration.msg
@@ -1,2 +1,2 @@
-Header header
-duration data
+std_msgs/Header header
+builtin_interfaces/Duration data

--- a/msg/DurationArray.msg
+++ b/msg/DurationArray.msg
@@ -1,2 +1,2 @@
-Header header
-duration[] data
+std_msgs/Header header
+builtin_interfaces/Duration[] data

--- a/msg/DurationArray.msg
+++ b/msg/DurationArray.msg
@@ -1,2 +1,2 @@
 std_msgs/Header header
-builtin_interfaces/Duration[] data
+duration[] data

--- a/msg/Empty.msg
+++ b/msg/Empty.msg
@@ -1,1 +1,1 @@
-Header header
+std_msgs/Header header

--- a/msg/Float32.msg
+++ b/msg/Float32.msg
@@ -1,2 +1,2 @@
-Header header
+std_msgs/Header header
 float32 data

--- a/msg/Float32Array.msg
+++ b/msg/Float32Array.msg
@@ -1,2 +1,2 @@
-Header header
+std_msgs/Header header
 float32[] data

--- a/msg/Float32MultiArray.msg
+++ b/msg/Float32MultiArray.msg
@@ -1,3 +1,3 @@
-Header header
+std_msgs/Header header
 std_msgs/MultiArrayLayout  layout        # specification of data layout
 float32[] data

--- a/msg/Float64.msg
+++ b/msg/Float64.msg
@@ -1,2 +1,2 @@
-Header header
+std_msgs/Header header
 float64 data

--- a/msg/Float64Array.msg
+++ b/msg/Float64Array.msg
@@ -1,2 +1,2 @@
-Header header
+std_msgs/Header header
 float64[] data

--- a/msg/Float64MultiArray.msg
+++ b/msg/Float64MultiArray.msg
@@ -1,3 +1,3 @@
-Header header
+std_msgs/Header header
 std_msgs/MultiArrayLayout  layout        # specification of data layout
 float64 data

--- a/msg/Int16.msg
+++ b/msg/Int16.msg
@@ -1,2 +1,2 @@
-Header header
+std_msgs/Header header
 int16 data

--- a/msg/Int16Array.msg
+++ b/msg/Int16Array.msg
@@ -1,2 +1,2 @@
-Header header
+std_msgs/Header header
 int16[] data

--- a/msg/Int16MultiArray.msg
+++ b/msg/Int16MultiArray.msg
@@ -1,3 +1,3 @@
-Header header
+std_msgs/Header header
 std_msgs/MultiArrayLayout  layout        # specification of data layout
 int16[] data

--- a/msg/Int32.msg
+++ b/msg/Int32.msg
@@ -1,2 +1,2 @@
-Header header
+std_msgs/Header header
 int32 data

--- a/msg/Int32Array.msg
+++ b/msg/Int32Array.msg
@@ -1,2 +1,2 @@
-Header header
+std_msgs/Header header
 int32[] data

--- a/msg/Int32MultiArray.msg
+++ b/msg/Int32MultiArray.msg
@@ -1,3 +1,3 @@
-Header header
+std_msgs/Header header
 std_msgs/MultiArrayLayout  layout        # specification of data layout
 int32[] data

--- a/msg/Int64.msg
+++ b/msg/Int64.msg
@@ -1,2 +1,2 @@
-Header header
+std_msgs/Header header
 int64 data

--- a/msg/Int64Array.msg
+++ b/msg/Int64Array.msg
@@ -1,2 +1,2 @@
-Header header
+std_msgs/Header header
 int64[] data

--- a/msg/Int64MultiArray.msg
+++ b/msg/Int64MultiArray.msg
@@ -1,3 +1,3 @@
-Header header
+std_msgs/Header header
 std_msgs/MultiArrayLayout  layout        # specification of data layout
 int64[] data

--- a/msg/Int8.msg
+++ b/msg/Int8.msg
@@ -1,2 +1,2 @@
-Header header
+std_msgs/Header header
 int8 data

--- a/msg/Int8Array.msg
+++ b/msg/Int8Array.msg
@@ -1,2 +1,2 @@
-Header header
+std_msgs/Header header
 int8[] data

--- a/msg/Int8MultiArray.msg
+++ b/msg/Int8MultiArray.msg
@@ -1,3 +1,3 @@
-Header header
+std_msgs/Header header
 std_msgs/MultiArrayLayout  layout        # specification of data layout
 int8[] data

--- a/msg/String.msg
+++ b/msg/String.msg
@@ -1,2 +1,2 @@
-Header header
+std_msgs/Header header
 string data

--- a/msg/StringArray.msg
+++ b/msg/StringArray.msg
@@ -1,2 +1,2 @@
-Header header
+std_msgs/Header header
 string[] data

--- a/msg/UInt16.msg
+++ b/msg/UInt16.msg
@@ -1,2 +1,2 @@
-Header header
+std_msgs/Header header
 uint16 data

--- a/msg/UInt16Array.msg
+++ b/msg/UInt16Array.msg
@@ -1,2 +1,2 @@
-Header header
+std_msgs/Header header
 uint16[] data

--- a/msg/UInt16MultiArray.msg
+++ b/msg/UInt16MultiArray.msg
@@ -1,3 +1,3 @@
-Header header
+std_msgs/Header header
 std_msgs/MultiArrayLayout  layout        # specification of data layout
 uint16[] data

--- a/msg/UInt32.msg
+++ b/msg/UInt32.msg
@@ -1,2 +1,2 @@
-Header header
+std_msgs/Header header
 uint32 data

--- a/msg/UInt32Array.msg
+++ b/msg/UInt32Array.msg
@@ -1,2 +1,2 @@
-Header header
+std_msgs/Header header
 uint32[] data

--- a/msg/UInt32MultiArray.msg
+++ b/msg/UInt32MultiArray.msg
@@ -1,3 +1,3 @@
-Header header
+std_msgs/Header header
 std_msgs/MultiArrayLayout  layout        # specification of data layout
 uint32[] data

--- a/msg/UInt64.msg
+++ b/msg/UInt64.msg
@@ -1,2 +1,2 @@
-Header header
+std_msgs/Header header
 uint64 data

--- a/msg/UInt64Array.msg
+++ b/msg/UInt64Array.msg
@@ -1,2 +1,2 @@
-Header header
+std_msgs/Header header
 uint64[] data

--- a/msg/UInt64MultiArray.msg
+++ b/msg/UInt64MultiArray.msg
@@ -1,3 +1,3 @@
-Header header
+std_msgs/Header header
 std_msgs/MultiArrayLayout  layout        # specification of data layout
 uint64[] data

--- a/msg/UInt8.msg
+++ b/msg/UInt8.msg
@@ -1,2 +1,2 @@
-Header header
+std_msgs/Header header
 uint8 data

--- a/msg/UInt8Array.msg
+++ b/msg/UInt8Array.msg
@@ -1,2 +1,2 @@
-Header header
+std_msgs/Header header
 uint8[] data

--- a/msg/UInt8MultiArray.msg
+++ b/msg/UInt8MultiArray.msg
@@ -1,3 +1,3 @@
-Header header
+std_msgs/Header header
 std_msgs/MultiArrayLayout  layout        # specification of data layout
 uint8[] data

--- a/msg_ros2/msg/Duration.msg
+++ b/msg_ros2/msg/Duration.msg
@@ -1,0 +1,2 @@
+std_msgs/Header header
+builtin_interfaces/Duration data

--- a/msg_ros2/msg/DurationArray.msg
+++ b/msg_ros2/msg/DurationArray.msg
@@ -1,0 +1,2 @@
+std_msgs/Header header
+builtin_interfaces/Duration[] data

--- a/package.xml
+++ b/package.xml
@@ -11,17 +11,21 @@
 
   <license>BSD</license>
 
-  <buildtool_depend>ament_cmake</buildtool_depend>
-  <buildtool_depend>rosidl_default_generators</buildtool_depend>
+  <buildtool_depend condition="$ROS_VERSION == 1">catkin</buildtool_depend>
+  <build_depend condition="$ROS_VERSION == 1">message_generation</build_depend>
+  <build_export_depend condition="$ROS_VERSION == 1">message_runtime</build_export_depend>
+  <exec_depend condition="$ROS_VERSION == 1">message_runtime</exec_depend>
+
+  <buildtool_depend condition="$ROS_VERSION == 2">ament_cmake</buildtool_depend>
+  <build_depend condition="$ROS_VERSION == 2">rosidl_default_generators</build_depend>
+  <exec_depend condition="$ROS_VERSION == 2">rosidl_default_runtime</exec_depend>
+  <member_of_group condition="$ROS_VERSION == 2">rosidl_interface_packages</member_of_group>
+  <depend condition="$ROS_VERSION == 2">builtin_interfaces</depend>
 
   <depend>std_msgs</depend>
-  <depend>builtin_interfaces</depend>
-
-  <exec_depend>rosidl_default_runtime</exec_depend>
-
-  <member_of_group>rosidl_interface_packages</member_of_group>
 
   <export>
-    <build_type>ament_cmake</build_type>
+    <build_type condition="$ROS_VERSION == 1">catkin</build_type>
+    <build_type condition="$ROS_VERSION == 2">ament_cmake</build_type>
   </export>
 </package>

--- a/package.xml
+++ b/package.xml
@@ -1,5 +1,6 @@
 <?xml version="1.0"?>
-<package format="2">
+<?xml-model href="http://download.ros.org/schema/package_format3.xsd" schematypens="http://www.w3.org/2001/XMLSchema"?>
+<package format="3">
   <name>stamped_msgs</name>
 
   <version>1.0.1</version>
@@ -10,15 +11,17 @@
 
   <license>BSD</license>
 
-  <buildtool_depend>catkin</buildtool_depend>
+  <buildtool_depend>ament_cmake</buildtool_depend>
+  <buildtool_depend>rosidl_default_generators</buildtool_depend>
 
   <depend>std_msgs</depend>
-  
-  <build_depend>message_generation</build_depend>
-  <build_export_depend>message_runtime</build_export_depend>
-  <exec_depend>message_runtime</exec_depend>
+  <depend>builtin_interfaces</depend>
+
+  <exec_depend>rosidl_default_runtime</exec_depend>
+
+  <member_of_group>rosidl_interface_packages</member_of_group>
 
   <export>
-    <architecture_independent/>
+    <build_type>ament_cmake</build_type>
   </export>
 </package>


### PR DESCRIPTION
Makes the `stamped_msgs` package compatible with both ROS 1 and ROS 2 simultaneously, following the pattern used by [septentrio_gnss_driver](https://github.com/septentrio-gnss/septentrio_gnss_driver).

## Changes Made

- **`CMakeLists.txt`**: Detects the build system via `find_package(catkin QUIET)` / `find_package(ament_cmake QUIET)` and branches into the appropriate ROS 1 (catkin) or ROS 2 (ament_cmake + rosidl) build configuration.
- **`package.xml`**: Updated to format 3 with `$ROS_VERSION` conditional dependencies so each ROS version receives the correct buildtool, message generators, and runtime dependencies.
- **`msg/Duration.msg`** and **`msg/DurationArray.msg`**: Use ROS 1's primitive `duration` type (compatible with catkin).
- **`msg_ros2/msg/Duration.msg`** and **`msg_ros2/msg/DurationArray.msg`**: New alternative message files using `builtin_interfaces/Duration` for ROS 2 builds. These are referenced via the `search_path:relative_path` syntax in `rosidl_generate_interfaces` so the generated message type names remain identical across both ROS versions.
- All other message files use `std_msgs/Header` (fully-qualified, valid in both ROS 1 and ROS 2).